### PR TITLE
`gems` was depcrecated and moved to `plugins`.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ dates:
 markdown: kramdown
 
 # Plugins
-gems:
+plugins:
   - jekyll-redirect-from
 
 # Page Settings


### PR DESCRIPTION
Prior to this change, we used the old setting.

This change updates us.

```diff
$ bundle exec jekyll serve
Configuration file: ./_config.yml
-       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```