### PR TITLE
Keynote abstracts, aesthetic fixes

### DIFF
--- a/_data/header_menu.yml
+++ b/_data/header_menu.yml
@@ -1,7 +1,5 @@
 - title: News
   link: https://blog.rustfest.eu/
-- title: Talks
-  link: /talks/
 - title: Schedule
   link: /schedule/
 - title: Workshops

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -53,6 +53,13 @@ section ol {
     color: $brand_yellow;
     font-style: bold;
   }
+
+  .note {
+    font-size: 0.8em;
+    a, a:visited {
+      color: $brand_yellow;
+    }
+  }
 }
 
 .cfp-button {

--- a/_sessions/keynote-learning-how-to-learn.html
+++ b/_sessions/keynote-learning-how-to-learn.html
@@ -9,7 +9,7 @@ speakers:
 title: Learning how to Learn
 special: Keynote
 desc: >
-  TBA
+  A good education can take many different shapes, sizes, forms. Oftentimes, the most profound educations don't even happen in a classroom. And yet, they all seem to have one thing in common: they teach you how to learn. Being able to learn new things is an empowering skills, especially for those of us working in the ever-changing, fast-paced tech industry. But how can we teach ourselves this skill? Together, we’ll explore one of the world’s most well-known and deeply-loved techniques, which we can use to learn many new things, tech-related and not!
 
 socialTwitterCardType: summary_large_image
 socialImageSrc: /assets/social/vaidehi.png

--- a/_sessions/keynote-supercharging-rust-communities.html
+++ b/_sessions/keynote-supercharging-rust-communities.html
@@ -9,7 +9,7 @@ speakers:
 title: Supercharging Rust Communities
 special: Keynote
 desc: >
-  TBA
+  Ever wondered what makes Rust successful? This talk is about growing Rust communities worldwide and emulating values and ideals that have made the Rust project a success. Come and learn how these values and ideals have influenced Rust Nairobi's journey and how you can use them as guidelines for your community.
 
 socialTwitterCardType: summary_large_image
 socialImageSrc: /assets/social/matt.png

--- a/index.html
+++ b/index.html
@@ -37,7 +37,9 @@ bodytags: with-hero
         <p class="desc">Impl Days</p>
         <p>
           {{site.dates.impl_days}}, {{site.dates.year}}
-          (<a href="/about_impl_days/">What is <code class="highlighter-rouge">impl Days</code>?</a>)
+          <p class="note">
+            <a href="/about_impl_days/">⇨ What is <code class="highlighter-rouge">impl Days</code>?</a>
+          </p>
         </p>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ bodytags: with-hero
         <p>
           {{site.dates.impl_days}}, {{site.dates.year}}
           <p class="note">
-            <a href="/about_impl_days/">⇨ What is <code class="highlighter-rouge">impl Days</code>?</a>
+            <a href="/about_impl_days/">What is <code class="highlighter-rouge">impl Days</code>?</a>
           </p>
         </p>
       </div>

--- a/schedule.html
+++ b/schedule.html
@@ -7,7 +7,8 @@ title: Schedule
 <div class='popout'>
   <section>
     <h1>RustFest {{site.location.city}} {{site.dates.year}} - Schedule {% include icons/calendar.svg %}</h1>
-    <h2>Location: <a href="/location/">{{site.location.venue}}, 199 bis, rue Saint-Martin, 75003 Paris.</a>.</h2>
+    <a href="/talks">☰ List of Speakers</a>
+    <h2>Location: <a href="/location/">{{site.location.venue}}, 199 bis, rue Saint-Martin, 75003 Paris</a>.</h2>
   </section>
 </div>
 

--- a/talks.html
+++ b/talks.html
@@ -7,6 +7,7 @@ title: Talks
 <div class="popout">
   <section>
       <h1>RustFest Paris 2018 Talks</h1>
+    <a href="/schedule">☷ Talk Schedule</a>
   </section>
 </div>
 


### PR DESCRIPTION
This adds the keynote abstracts, compresses the header menu a bit and makes the impl Days link on the front page a bit nicer.

## Screenshots:

Removed "Talks" menu item:
![header menu](https://user-images.githubusercontent.com/50564/40311470-27f8746e-5d10-11e8-8891-6745d3831960.png)

"Talks" is now a link in schedule ("List of Speakers"):
![schedule](https://user-images.githubusercontent.com/50564/40311406-f4d9a0da-5d0f-11e8-927b-41a0c0521ef7.png)

New front page hero (tweaked impl Days link):
![front page hero](https://user-images.githubusercontent.com/50564/40311361-cd94f420-5d0f-11e8-882b-05e8915829cb.png)


